### PR TITLE
Commerce 149

### DIFF
--- a/commerce-product-type-virtual-web/src/main/resources/META-INF/resources/definition_virtual_setting/terms_of_use.jsp
+++ b/commerce-product-type-virtual-web/src/main/resources/META-INF/resources/definition_virtual_setting/terms_of_use.jsp
@@ -22,6 +22,7 @@ CPDefinitionVirtualSettingDisplayContext cpDefinitionVirtualSettingDisplayContex
 CPDefinitionVirtualSetting cpDefinitionVirtualSetting = cpDefinitionVirtualSettingDisplayContext.getCPDefinitionVirtualSetting();
 
 JournalArticle journalArticle = cpDefinitionVirtualSettingDisplayContext.getJournalArticle();
+boolean termsOfUseRequired = BeanParamUtil.getBoolean(cpDefinitionVirtualSetting, request, "termsOfUseRequired");
 
 long termsOfUseJournalArticleResourcePrimKey = BeanParamUtil.getLong(cpDefinitionVirtualSetting, request, "termsOfUseJournalArticleResourcePrimKey");
 
@@ -44,51 +45,55 @@ if (termsOfUseJournalArticleResourcePrimKey > 0) {
 <liferay-ui:error exception="<%= CPDefinitionVirtualSettingTermsOfUseException.class %>" message="please-select-an-existing-web-content-or-enter-terms-of-use-content" />
 
 <aui:fieldset>
-	<aui:input label="enable-terms-of-use" name="termsOfUseRequired" />
+	<aui:input label="enable-terms-of-use" name="termsOfUseRequired" type="toggle-switch" value="<%= termsOfUseRequired %>" />
 </aui:fieldset>
 
-<div class="col-md-3">
-	<h4 class="text-default"><liferay-ui:message key="select-existing-content-or-add-terms-of-use-in-the-space-below" /></h4>
-</div>
+<div class="row" id="<portlet:namespace />termsOfUseSettings">
+	<div class="col-md-3">
+		<h4 class="text-default"><liferay-ui:message key="select-existing-content-or-add-terms-of-use-in-the-space-below" /></h4>
+	</div>
 
-<div class="col-md-9">
-	<aui:fieldset>
-		<p class="text-default">
-			<span class="<%= (termsOfUseJournalArticleResourcePrimKey > 0) ? StringPool.BLANK : "hide" %>" id="<portlet:namespace />journalArticleRemove" role="button">
-				<aui:icon cssClass="icon-monospaced" image="times" markupView="lexicon" />
-			</span>
-			<span id="<portlet:namespace />journalArticleNameInput">
-				<c:choose>
-					<c:when test="<%= journalArticle != null %>">
-						<%= journalArticle.getTitle() %>
-					</c:when>
-					<c:otherwise>
-						<span class="text-muted"><liferay-ui:message key="none" /></span>
-					</c:otherwise>
-				</c:choose>
-			</span>
-		</p>
+	<div class="col-md-9">
+		<aui:fieldset>
+			<p class="text-default">
+				<span class="<%= (termsOfUseJournalArticleResourcePrimKey > 0) ? StringPool.BLANK : "hide" %>" id="<portlet:namespace />journalArticleRemove" role="button">
+					<aui:icon cssClass="icon-monospaced" image="times" markupView="lexicon" />
+				</span>
+				<span id="<portlet:namespace />journalArticleNameInput">
+					<c:choose>
+						<c:when test="<%= journalArticle != null %>">
+							<%= journalArticle.getTitle() %>
+						</c:when>
+						<c:otherwise>
+							<span class="text-muted"><liferay-ui:message key="none" /></span>
+						</c:otherwise>
+					</c:choose>
+				</span>
+			</p>
 
-		<aui:button name="selectArticle" value="select-web-content" />
+			<aui:button name="selectArticle" value="select-web-content" />
 
-		<aui:field-wrapper cssClass="lfr-definition-virtual-setting-content">
-			<h4 class="text-default"><liferay-ui:message key="or" /></h4>
+			<aui:field-wrapper cssClass="lfr-definition-virtual-setting-content">
+				<h4 class="text-default"><liferay-ui:message key="or" /></h4>
 
-			<div class="entry-content form-group">
-				<liferay-ui:input-localized
-					cssClass="form-control"
-					disabled="<%= useTermsOfUseJournal %>"
-					editorName="alloyeditor"
-					name="termsOfUseContent"
-					type="editor"
-					xml='<%= BeanPropertiesUtil.getString(cpDefinitionVirtualSetting, "termsOfUseContent") %>'
-				/>
-			</div>
-		</aui:field-wrapper>
-	</aui:fieldset>
+				<div class="entry-content form-group">
+					<liferay-ui:input-localized
+						cssClass="form-control"
+						disabled="<%= useTermsOfUseJournal %>"
+						editorName="alloyeditor"
+						name="termsOfUseContent"
+						type="editor"
+						xml='<%= BeanPropertiesUtil.getString(cpDefinitionVirtualSetting, "termsOfUseContent") %>'
+					/>
+				</div>
+			</aui:field-wrapper>
+		</aui:fieldset>
+	</div>
 </div>
 
 <aui:script sandbox="<%= true %>">
+	Liferay.Util.toggleBoxes('<portlet:namespace />termsOfUseRequired', '<portlet:namespace />termsOfUseSettings');
+
 	var journalArticleRemove = $('#<portlet:namespace />journalArticleRemove');
 	var journalArticleNameInput = $('#<portlet:namespace />journalArticleNameInput');
 
@@ -112,8 +117,6 @@ if (termsOfUseJournalArticleResourcePrimKey > 0) {
 				function(event) {
 					$('#<portlet:namespace />termsOfUseJournalArticleResourcePrimKey').val(event.assetclasspk);
 
-					$('#<portlet:namespace />termsOfUseContent').attr('disabled', true);
-
 					journalArticleRemove.removeClass('hide');
 
 					journalArticleNameInput.html(event.assettitle);
@@ -127,12 +130,6 @@ if (termsOfUseJournalArticleResourcePrimKey > 0) {
 		function(event) {
 			event.preventDefault();
 
-			var contentCheckbox = $('#<portlet:namespace />termsOfUseRequired');
-
-			if (contentCheckbox.attr('checked')) {
-				$('#<portlet:namespace />termsOfUseContent').attr('disabled', false);
-			}
-
 			$('#<portlet:namespace />termsOfUseJournalArticleResourcePrimKey').val(0);
 
 			journalArticleNameInput.html('<liferay-ui:message key="none" />');
@@ -140,35 +137,4 @@ if (termsOfUseJournalArticleResourcePrimKey > 0) {
 			journalArticleRemove.addClass('hide');
 		}
 	);
-</aui:script>
-
-<aui:script>
-	AUI().ready(
-		'node', 'event',
-		function(A) {
-			selectContentType(A);
-
-			A.one('#<portlet:namespace />termsOfUseRequired').on(
-				'click',
-				function(b) {
-					selectContentType(A);
-				}
-			);
-		}
-	);
-
-	function selectContentType(A) {
-		var contentCheckbox = A.one('#<portlet:namespace />termsOfUseRequired');
-
-		var isContentSelected = A.one('#<portlet:namespace />journalArticleRemove').hasClass('hide');
-
-		if (contentCheckbox.attr('checked')) {
-			A.one('#<portlet:namespace />selectArticle').attr('disabled', false);
-			A.one('#<portlet:namespace />termsOfUseContent').attr('disabled', !isContentSelected);
-		}
-		else {
-			A.one('#<portlet:namespace />selectArticle').attr('disabled', true);
-			A.one('#<portlet:namespace />termsOfUseContent').attr('disabled', true);
-		}
-	}
 </aui:script>


### PR DESCRIPTION
I did find another bug with the original code that persisted in this fix:

Enable ToU, type something into the textarea, then click save.
After it's saved, disabled ToU and save again.
Then re-enable ToU.

Expected Behavior: 
Textarea is visible

Actual Behavior:
Textarea is missing and there is an error in the console.