### PR TITLE
COMMERCE-787 Fix 'End After' field staying hidden after multiple toggles

### DIFF
--- a/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_definition_subscription_info.jsp
+++ b/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_definition_subscription_info.jsp
@@ -95,15 +95,7 @@ boolean ending = maxSubscriptionCycles > 0;
 						<aui:input checked="<%= ending ? false : true %>" name="neverEnds" type="toggle-switch" />
 					</div>
 
-					<%
-					String cssClass = "never-ends-content hide";
-
-					if (ending) {
-						cssClass = "never-ends-content";
-					}
-					%>
-
-					<div class="<%= cssClass %>">
+					<div class="never-ends-content">
 						<aui:input disabled="<%= ending ? false : true %>" helpMessage="max-subscription-cycles-help" label="end-after" name="maxSubscriptionCycles" suffix='<%= LanguageUtil.get(request, "cycles") %>' value="<%= String.valueOf(maxSubscriptionCycles) %>">
 							<aui:validator name="digits" />
 
@@ -113,7 +105,11 @@ boolean ending = maxSubscriptionCycles > 0;
 										return true;
 									}
 
-									return (parseInt(val, 10) > 0);
+									if (parseInt(val, 10) > 0) {
+										return true;
+									}
+
+									return false;
 								}
 							</aui:validator>
 						</aui:input>
@@ -179,16 +175,10 @@ boolean ending = maxSubscriptionCycles > 0;
 				animatingChange: function(event) {
 					var instance = this;
 
-					var expanded = !instance.get('expanded');
-
-					if (expanded) {
-						A.one('#<portlet:namespace />neverEndsContainer .never-ends-content').removeClass('hide');
-
+					if (!instance.get('expanded')) {
 						A.one('#<portlet:namespace />maxSubscriptionCycles').attr('disabled', false);
 					}
 					else {
-						A.one('#<portlet:namespace />neverEndsContainer .never-ends-content').addClass('hide');
-
 						A.one('#<portlet:namespace />maxSubscriptionCycles').attr('disabled', true);
 					}
 				}

--- a/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_instance_subscription_info.jsp
+++ b/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_instance_subscription_info.jsp
@@ -106,15 +106,7 @@ boolean ending = maxSubscriptionCycles > 0;
 							<aui:input checked="<%= ending ? false : true %>" name="neverEnds" type="toggle-switch" />
 						</div>
 
-						<%
-						String cssClass = "never-ends-content hide";
-
-						if (ending) {
-							cssClass = "never-ends-content";
-						}
-						%>
-
-						<div class="<%= cssClass %>">
+						<div class="never-ends-content">
 							<aui:input disabled="<%= ending ? false : true %>" helpMessage="max-subscription-cycles-help" label="end-after" name="maxSubscriptionCycles" suffix='<%= LanguageUtil.get(request, "cycles") %>' value="<%= String.valueOf(maxSubscriptionCycles) %>">
 								<aui:validator name="digits" />
 
@@ -124,7 +116,11 @@ boolean ending = maxSubscriptionCycles > 0;
 											return true;
 										}
 
-										return (parseInt(val, 10) > 0);
+										if (parseInt(val, 10) > 0) {
+											return true;
+										}
+
+										return false;
 									}
 								</aui:validator>
 							</aui:input>
@@ -195,16 +191,10 @@ boolean ending = maxSubscriptionCycles > 0;
 				animatingChange: function(event) {
 					var instance = this;
 
-					var expanded = !instance.get('expanded');
-
-					if (expanded) {
-						A.one('#<portlet:namespace />neverEndsContainer .never-ends-content').removeClass('hide');
-
+					if (!instance.get('expanded')) {
 						A.one('#<portlet:namespace />maxSubscriptionCycles').attr('disabled', false);
 					}
 					else {
-						A.one('#<portlet:namespace />neverEndsContainer .never-ends-content').addClass('hide');
-
 						A.one('#<portlet:namespace />maxSubscriptionCycles').attr('disabled', true);
 					}
 				}

--- a/commerce-subscription-web/src/main/resources/META-INF/resources/subscription_entry/details.jsp
+++ b/commerce-subscription-web/src/main/resources/META-INF/resources/subscription_entry/details.jsp
@@ -101,15 +101,7 @@ if (maxSubscriptionCycles > 0) {
 					<aui:input checked="<%= finiteSubscription ? false : true %>" name="neverEnds" type="toggle-switch" />
 				</div>
 
-				<%
-				String cssClass = "never-ends-content hide";
-
-				if (finiteSubscription) {
-					cssClass = "never-ends-content";
-				}
-				%>
-
-				<div class="<%= cssClass %>">
+				<div class="never-ends-content">
 					<aui:input disabled="<%= finiteSubscription ? false : true %>" helpMessage="max-subscription-cycles-help" label="end-after" name="maxSubscriptionCycles" suffix='<%= LanguageUtil.get(request, "cycles") %>' value="<%= String.valueOf(maxSubscriptionCycles) %>">
 						<aui:validator name="digits" />
 
@@ -205,13 +197,9 @@ if (maxSubscriptionCycles > 0) {
 					var instance = this;
 
 					if (!instance.get('expanded')) {
-						A.one('#<portlet:namespace />neverEndsContainer .never-ends-content').removeClass('hide');
-
 						A.one('#<portlet:namespace />maxSubscriptionCycles').attr('disabled', false);
 					}
 					else {
-						A.one('#<portlet:namespace />neverEndsContainer .never-ends-content').addClass('hide');
-
 						A.one('#<portlet:namespace />maxSubscriptionCycles').attr('disabled', true);
 					}
 				}


### PR DESCRIPTION
This one was really simple, let me know if you have any questions.